### PR TITLE
Reworked player teleport

### DIFF
--- a/lib/game/game_server.ex
+++ b/lib/game/game_server.ex
@@ -481,12 +481,6 @@ defmodule ThistleTea.Game do
       mobs_to_add = MapSet.difference(new_mobs, old_mobs)
       game_objects_to_add = MapSet.difference(new_game_objects, old_game_objects)
 
-      #dbg(mobs_to_remove)
-
-      if MapSet.size(mobs_to_add) > 0 do
-       dbg(mobs_to_add)
-      end
-
       # TODO: update a reverse mapping, so mobs know nearby players?
       for {guid, pid} <- players_to_remove do
         if pid != self() do

--- a/lib/game/game_server.ex
+++ b/lib/game/game_server.ex
@@ -387,7 +387,11 @@ defmodule ThistleTea.Game do
       z
     )
 
-    state = Map.put(state, :character, character)
+    state =
+      Map.merge(state, %{
+        character: character,
+        ready: false
+      })
 
     # Send player's client the new location
     orientation = 0
@@ -404,7 +408,7 @@ defmodule ThistleTea.Game do
 
     # The client responds with a MSG_MOVE_WORLDPORT_ACK message which
     # is handled in the login handler as they share the same init process
-    {:noreply, {socket, state |> Map.put(:ready, false)}, socket.read_timeout}
+    {:noreply, {socket, state}, socket.read_timeout}
   end
 
   @impl GenServer

--- a/lib/game/handlers/chat.ex
+++ b/lib/game/handlers/chat.ex
@@ -13,9 +13,6 @@ defmodule ThistleTea.Game.Chat do
   # @smsg_channel_list 0x09B
   @smsg_chat_player_not_found 0x2A9
 
-  @smsg_transfer_pending 0x03F
-  @smsg_new_world 0x03E
-
   @chat_type_say 0x0
   @chat_type_party 0x1
   # @chat_type_raid 0x2
@@ -79,49 +76,11 @@ defmodule ThistleTea.Game.Chat do
   end
 
   def teleport_player(state, x, y, z, map) do
-    # Send player's client to loading screen to load the new map
-    transfer_pending_packet = <<map::little-size(32)>>
-    send_packet(@smsg_transfer_pending, transfer_pending_packet)
+    system_message(state, "Teleporting to #{x}, #{y}, #{z} on map #{map}")
 
-    # Pause the spawning loop until we're ready for it
-    GenServer.cast(self(), :stop_spawning)
+    GenServer.cast(self(), {:start_teleport, x, y, z, map})
 
-    area =
-      case ThistleTea.Pathfinding.get_zone_and_area(map, {x, y, z}) do
-        {_zone, area} -> area
-        nil -> state.character.area
-      end
-
-    character =
-      state.character
-      |> Map.put(:area, area)
-      |> Map.put(:map, map)
-      |> Map.put(
-        :movement,
-        state.character.movement
-        |> Map.merge(%{x: x, y: y, z: z})
-      )
-
-    SpatialHash.update(
-      :players,
-      state.guid,
-      self(),
-      character.map,
-      x,
-      y,
-      z
-    )
-
-    # Tell player client the location change is finished to load in
-    Process.send_after(self(), {:teleport_complete, x, y, z, map}, 500)
-    #send_packet(@smsg_new_world, new_world_packet)
-
-    # Test this out with: 0 -8949.95, -132.493, 83.5312
-    # 1 -6240.32, 331.033, 382.758
-    #Process.send(self(), :logout_complete, [])
-
-    Map.put(state, :character, character)
-    |> system_message("Teleporting to #{x}, #{y}, #{z} on map #{map}")
+    state
   end
 
   defp parse_coords([x, y, z, map]) do

--- a/lib/game/handlers/chat/emote.ex
+++ b/lib/game/handlers/chat/emote.ex
@@ -1,6 +1,5 @@
 defmodule ThistleTea.Game.Chat.Emote do
   alias ThistleTea.Game.Chat
-  import ThistleTea.Util, only: [unpack_guid: 1]
 
   @range 25
 

--- a/lib/game/handlers/login.ex
+++ b/lib/game/handlers/login.ex
@@ -51,7 +51,7 @@ defmodule ThistleTea.Game.Login do
         c.movement.orientation::little-float-size(32)>>
     )
 
-    send_various_login_packets(c)
+    send_login_init_packets(c)
 
     {x1, y1, z1} = {c.movement.x, c.movement.y, c.movement.z}
 
@@ -71,21 +71,19 @@ defmodule ThistleTea.Game.Login do
   end
 
   def handle_packet(@msg_move_worldport_ack, body, state) do
+    # TODO: we can probably unify this handler and the above player login handler at some point
     Logger.info("MSG_MOVE_WORLDPORT_ACK")
 
-    # {:ok, c} = ThistleTea.Character.get_character(state.account.id, state.guid)
-    #dbg(c)
+    # Send the same login initialization packets to set things up again
+    send_login_init_packets(state.character)
 
-    send_various_login_packets(state.character)
-
-    dbg(state.character)
+    # Restart spawn loop
     Process.send(self(), :spawn_objects, [])
-    #dbg(c)
 
     {:continue, state}
   end
 
-  def send_various_login_packets(c) do
+  def send_login_init_packets(c) do
     # needed for no white chatbox + keybinds
     send_packet(
       @smsg_account_data_times,

--- a/lib/game/handlers/login.ex
+++ b/lib/game/handlers/login.ex
@@ -19,6 +19,8 @@ defmodule ThistleTea.Game.Login do
   @smsg_login_settimespeed 0x042
   @smsg_trigger_cinematic 0x0FA
 
+  @msg_move_worldport_ack 0x0DC
+
   # @update_flag_none 0x00
   @update_flag_self 0x01
   # @update_flag_transport 0x02
@@ -49,6 +51,41 @@ defmodule ThistleTea.Game.Login do
         c.movement.orientation::little-float-size(32)>>
     )
 
+    send_various_login_packets(c)
+
+    {x1, y1, z1} = {c.movement.x, c.movement.y, c.movement.z}
+
+    # join
+    SpatialHash.update(:players, character_guid, self(), c.map, x1, y1, z1)
+
+    new_state =
+      Map.merge(state, %{
+        guid: character_guid,
+        packed_guid: pack_guid(character_guid),
+        character: c
+      })
+
+    Process.send(self(), :spawn_objects, [])
+
+    {:continue, new_state}
+  end
+
+  def handle_packet(@msg_move_worldport_ack, body, state) do
+    Logger.info("MSG_MOVE_WORLDPORT_ACK")
+
+    # {:ok, c} = ThistleTea.Character.get_character(state.account.id, state.guid)
+    #dbg(c)
+
+    send_various_login_packets(state.character)
+
+    dbg(state.character)
+    Process.send(self(), :spawn_objects, [])
+    #dbg(c)
+
+    {:continue, state}
+  end
+
+  def send_various_login_packets(c) do
     # needed for no white chatbox + keybinds
     send_packet(
       @smsg_account_data_times,
@@ -123,21 +160,5 @@ defmodule ThistleTea.Game.Login do
 
     packet = build_update_packet(c, @update_type_create_object2, @object_type_player, update_flag)
     send_update_packet(packet)
-
-    {x1, y1, z1} = {c.movement.x, c.movement.y, c.movement.z}
-
-    # join
-    SpatialHash.update(:players, character_guid, self(), c.map, x1, y1, z1)
-
-    new_state =
-      Map.merge(state, %{
-        guid: character_guid,
-        packed_guid: pack_guid(character_guid),
-        character: c
-      })
-
-    Process.send(self(), :spawn_objects, [])
-
-    {:continue, new_state}
   end
 end

--- a/lib/game/handlers/login.ex
+++ b/lib/game/handlers/login.ex
@@ -36,7 +36,6 @@ defmodule ThistleTea.Game.Login do
 
   def handle_packet(@cmsg_player_login, body, state) do
     <<character_guid::little-size(64)>> = body
-    Logger.info("CMSG_PLAYER_LOGIN")
 
     {:ok, c} = ThistleTea.Character.get_character(state.account.id, character_guid)
 
@@ -73,12 +72,7 @@ defmodule ThistleTea.Game.Login do
   end
 
   def handle_packet(@msg_move_worldport_ack, _body, state) do
-    # TODO: we can probably unify this handler and the above player login handler at some point
-    Logger.info("MSG_MOVE_WORLDPORT_ACK")
-
-    # Send the same login initialization packets to set things up again
     send_login_init_packets(state.character)
-
     {:continue, state |> Map.put(:ready, true)}
   end
 

--- a/lib/game/handlers/logout.ex
+++ b/lib/game/handlers/logout.ex
@@ -39,6 +39,10 @@ defmodule ThistleTea.Game.Logout do
       ThistleTea.Character.save(state.character)
     end
 
+    if Map.get(state, :spawn_timer) do
+      :timer.cancel(state.spawn_timer)
+    end
+
     if Map.get(state, :guid) do
       # remove from map
       SpatialHash.remove(:players, state.guid)

--- a/lib/game/handlers/movement.ex
+++ b/lib/game/handlers/movement.ex
@@ -68,7 +68,7 @@ defmodule ThistleTea.Game.Movement do
     end
   end
 
-  def handle_packet(msg, body, state)
+  def handle_packet(msg, body, %{ready: true} = state)
       when msg in [
              @msg_move_start_forward,
              @msg_move_start_backward,
@@ -136,6 +136,10 @@ defmodule ThistleTea.Game.Movement do
       end
     end
 
+    {:continue, state}
+  end
+
+  def handle_packet(_msg, _body, state) do
     {:continue, state}
   end
 end

--- a/lib/game/handlers/movement.ex
+++ b/lib/game/handlers/movement.ex
@@ -38,14 +38,15 @@ defmodule ThistleTea.Game.Movement do
 
   @spell_failed_moving 0x2E
 
-  defp update_area(character) do
-    %{x: x, y: y, z: z} = character.movement
+  # TODO: this can crash, waiting for namigator fix
+  # defp update_area(character) do
+  #   %{x: x, y: y, z: z} = character.movement
 
-    case ThistleTea.Pathfinding.get_zone_and_area(character.map, {x, y, z}) do
-      {_zone, area} -> Map.put(character, :area, area)
-      nil -> character
-    end
-  end
+  #   case ThistleTea.Pathfinding.get_zone_and_area(character.map, {x, y, z}) do
+  #     {_zone, area} -> Map.put(character, :area, area)
+  #     nil -> character
+  #   end
+  # end
 
   defp randomize_equipment(state, msg) do
     if msg === @msg_move_jump do


### PR DESCRIPTION
This teleport process works in a few parts:
1. Tell the client to go to the loading screen (with a SMSG_TRANSFER_PENDING)
2. Update the player's location and send a SMSG_NEW_WORLD message
3. When the player's client is ready, the client sends a MSG_MOVE_WORLDPORT_ACK message and the server should respond with a lot of the similar information that happens in login

I moved the bulk of the teleport/transfer logic into the game_server/player handler since that mostly represents the player entity. I'm happy to back out of that change and move it back to the chat handler if we prefer that but I was wondering if it'd make sense to start centralizing some of the player-specific update logic to the player handler code.

I put the  MSG_MOVE_WORLDPORT_ACK  handler in login for now since it re-uses some of the login setup logic.

Again, lemme know if you have any thoughts on this organization stuff. Happy to re-work and find the right spot!

Closes #16