### PR TITLE
fix(deps): update transitive npm security fixes

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -37,9 +37,9 @@
       "license": "ISC"
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/geotiff": {
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT"
     },
     "node_modules/quick-lru": {

--- a/flake.nix
+++ b/flake.nix
@@ -127,7 +127,7 @@
             version = "0.1.0";
             src = ./assets;
             # Bump via `prefetch-npm-deps assets/package-lock.json`.
-            npmDepsHash = "sha256-TNxal2RxAA7Mo/MIqdV7n/tk2esYEuHrq7XkzteZHAo=";
+            npmDepsHash = "sha256-VUg28u7/6NWlpdwQSTucC8XotibqIBZsoHqjqmssYFk=";
             dontNpmBuild = true;
 
             installPhase = ''


### PR DESCRIPTION
Updates the two audited transitive frontend packages to their first patched versions: protocol-buffers-schema 3.6.1 and fflate 0.8.3. Refreshes the Nix npm dependency hash. Local Hex and Bun audits are clear; compile, tests, tagged integration tests, Credo, flake checks, and the production Nix build passed.